### PR TITLE
Updating version to 0.3.9 with timezone-js dependency version set to "<1"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name" : "angular-timezones",
-  "version" : "0.3.8",
+  "version" : "0.3.9",
 
   "main" : "js/angular-timezones.js",
 
@@ -19,6 +19,6 @@
     "angular" : "latest",
     "jquery" : "latest",
     "angular-filters" : "latest",
-    "timezone-js" : "git@github.com:mde/timezone-js.git#v0.4.4"
+    "timezone-js" : "~0.4.7"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     "angular" : "latest",
     "jquery" : "latest",
     "angular-filters" : "latest",
-    "timezone-js" : "~0.4.7"
+    "timezone-js" : "<1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name" : "angular-timezones",
   "description" : "Timezones for AngularJS",
-  "version" : "0.3.8",
+  "version" : "0.3.9",
   "homepage" : "https://github.com/michaelahlers/angular-timezones",
   "author" : {
     "name" : "Michael Ahlers",


### PR DESCRIPTION
Tag 0.3.9 exists on my fork. Could you please create it on your repo or pull mine in? The reason for this pull request is the hard version number on 0.3.8 for timezone-js set to 0.4.4. This wasn't playing nicely with automated builds since we would need to resolve dependency conflicts manually.
