### PR TITLE
Fixing bower.json to not use a URL that would not require git keys.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,6 +19,6 @@
     "angular" : "latest",
     "jquery" : "latest",
     "angular-filters" : "latest",
-    "timezone-js" : "git@github.com:mde/timezone-js.git#v0.4.4"
+    "timezone-js" : "https://github.com/mde/timezone-js.git#v0.4.4"
   }
 }


### PR DESCRIPTION
When bower.json uses "git@github.com:mde/timezone-js.git#v0.4.4" for a dependency, bower cannot install the dependency unless the user has their github ssh keys installed and has already used SSH to connect to github. Using "https://github.com/mde/timezone-js.git#v0.4.4" makes it possible to install the dependency without github keys.
